### PR TITLE
fix: add accountId to all webhook Received log lines

### DIFF
--- a/webhook.js
+++ b/webhook.js
@@ -21,6 +21,7 @@ export class WecomWebhook {
 
   constructor(config) {
     this.config = config;
+    this.accountId = config.accountId || "";
     this.crypto = new WecomCrypto(config.token, config.encodingAesKey);
     logger.debug("WecomWebhook initialized (AI Bot mode)");
   }
@@ -163,6 +164,7 @@ export class WecomWebhook {
       }
 
       logger.info("Received text message", {
+        accountId: this.accountId,
         fromUser,
         chatType,
         chatId: chatId || "(private)",
@@ -207,7 +209,7 @@ export class WecomWebhook {
         return WecomWebhook.DUPLICATE;
       }
 
-      logger.info("Received image message", { fromUser, chatType, imageUrl });
+      logger.info("Received image message", { accountId: this.accountId, fromUser, chatType, imageUrl });
 
       return {
         message: {
@@ -243,6 +245,7 @@ export class WecomWebhook {
       }
 
       logger.info("Received voice message (auto-transcribed by WeCom)", {
+        accountId: this.accountId,
         fromUser,
         chatType,
         chatId: chatId || "(private)",
@@ -299,6 +302,7 @@ export class WecomWebhook {
       const content = textParts.join("\n");
 
       logger.info("Received mixed message", {
+        accountId: this.accountId,
         fromUser,
         chatType,
         chatId: chatId || "(private)",
@@ -335,7 +339,7 @@ export class WecomWebhook {
         return WecomWebhook.DUPLICATE;
       }
 
-      logger.info("Received file message", { fromUser, fileName, fileUrl: fileUrl.substring(0, 80) });
+      logger.info("Received file message", { accountId: this.accountId, fromUser, fileName, fileUrl: fileUrl.substring(0, 80) });
 
       return {
         message: {
@@ -369,7 +373,7 @@ export class WecomWebhook {
         ? `[位置] ${name} (${latitude}, ${longitude})`
         : `[位置] ${latitude}, ${longitude}`;
 
-      logger.info("Received location message", { fromUser, latitude, longitude, name });
+      logger.info("Received location message", { accountId: this.accountId, fromUser, latitude, longitude, name });
 
       return {
         message: {
@@ -404,7 +408,7 @@ export class WecomWebhook {
       if (url) parts.push(url);
       const content = parts.join("\n") || "[链接]";
 
-      logger.info("Received link message", { fromUser, title, url: url.substring(0, 80) });
+      logger.info("Received link message", { accountId: this.accountId, fromUser, title, url: url.substring(0, 80) });
 
       return {
         message: {

--- a/wecom/http-handler.js
+++ b/wecom/http-handler.js
@@ -95,6 +95,7 @@ async function handleWecomRequest(req, res, targets, query, path) {
     const webhook = new WecomWebhook({
       token: target.account.token,
       encodingAesKey: target.account.encodingAesKey,
+      accountId: target.account.accountId,
     });
 
     const echo = webhook.handleVerify(query);
@@ -145,6 +146,7 @@ async function handleWecomRequest(req, res, targets, query, path) {
     const webhook = new WecomWebhook({
       token: target.account.token,
       encodingAesKey: target.account.encodingAesKey,
+      accountId: target.account.accountId,
     });
 
     const result = await webhook.handleMessage(query, body);


### PR DESCRIPTION
## Summary

- 多账号部署时（如 default/yoyo/itxiaoliu），webhook 的 "Received xxx message" 日志缺少 accountId，无法区分消息来自哪个账号，排查路由问题时是盲区
- 在 `WecomWebhook` 构造函数中保存 `accountId`，并在所有 6 处 "Received" 日志行加入 `accountId` 字段
- 在 `http-handler.js` 的 2 处 `new WecomWebhook()` 调用中传入 `accountId`

## Changed files

| File | Change |
|------|--------|
| `webhook.js` | Store `this.accountId` in constructor; add `accountId` to all 6 "Received" log lines |
| `wecom/http-handler.js` | Pass `accountId: target.account.accountId` in 2 `new WecomWebhook()` calls |

## Test plan

- [ ] Deploy with multi-account config, send messages to different accounts
- [ ] Verify each "Received" log line includes the correct `accountId`
- [ ] Verify single-account setups still work (accountId defaults to empty string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)