### PR TITLE
fix: 修复Windows作为服务器时，发送Media的路径解析问题

### DIFF
--- a/wecom/callback-inbound.js
+++ b/wecom/callback-inbound.js
@@ -168,7 +168,8 @@ export function parseCallbackMessageXml(xml) {
 // ---------------------------------------------------------------------------
 
 async function loadLocalReplyMedia(mediaUrl, config, agentId, runtime) {
-  const normalized = String(mediaUrl ?? "").trim().replaceAll("\\", "/");;
+  const normalized = !String(mediaUrl ?? "").trim().startsWith("\\") ? String(mediaUrl ?? "").trim() :
+                      String(mediaUrl ?? "").trim().replace("\\", "/");
   if (!normalized.startsWith("/") && !normalized.startsWith("sandbox:")) {
     throw new Error(`Unsupported callback reply media URL scheme: ${mediaUrl}`);
   }


### PR DESCRIPTION
使用Win作为OpenClaw服务器时，运行到callback-inbounds.js/loadLocalReplyMedia方法时发现，解析出来的mediaUrl会有问题，所有的/变成了\，这里新增了一个replace的方法。

P.S. 最合理的方式应该还是追溯到前面的解析部分去处理，这个pr可先作为一个临时解决方案