### PR TITLE
Honor reply media roots and skip empty group mentions

### DIFF
--- a/tests/reply-media-directive.test.js
+++ b/tests/reply-media-directive.test.js
@@ -2,7 +2,11 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { wsMonitorTesting, buildReplyMediaGuidance } from "../wecom/ws-monitor.js";
+import {
+  wsMonitorTesting,
+  buildReplyMediaGuidance,
+  resolveReplyMediaLocalRoots,
+} from "../wecom/ws-monitor.js";
 
 const { splitReplyMediaFromText, buildBodyForAgent, normalizeReplyMediaUrlForLoad } = wsMonitorTesting;
 
@@ -109,6 +113,38 @@ describe("buildReplyMediaGuidance", () => {
     assert.ok(guidance.includes("SKILL.md"));
     assert.ok(guidance.includes("path prefixed with FILE:"));
     assert.ok(guidance.includes("its own line"));
+  });
+
+  it("includes configured host media roots in guidance", () => {
+    const guidance = buildReplyMediaGuidance(
+      {
+        channels: {
+          wecom: {
+            mediaLocalRoots: ["/tmp/reply-media"],
+          },
+        },
+      },
+      "test-agent",
+    );
+    assert.ok(guidance.includes("Additional configured host roots are also allowed: /tmp/reply-media"));
+  });
+});
+
+describe("resolveReplyMediaLocalRoots", () => {
+  it("merges configured mediaLocalRoots with workspace and browser roots", () => {
+    const roots = resolveReplyMediaLocalRoots(
+      {
+        channels: {
+          wecom: {
+            mediaLocalRoots: ["/tmp/reply-media"],
+          },
+        },
+      },
+      "test-agent",
+    );
+    assert.ok(roots.includes("/tmp/reply-media"));
+    assert.ok(roots.includes(path.join(os.homedir(), ".openclaw", "workspace-test-agent")));
+    assert.ok(roots.includes(path.join(os.homedir(), ".openclaw", "media", "browser")));
   });
 });
 

--- a/tests/ws.e2e.test.js
+++ b/tests/ws.e2e.test.js
@@ -516,6 +516,38 @@ describe("WS e2e", () => {
     }
   });
 
+  it("skips mention-only group messages instead of replying with a completion placeholder", async () => {
+    const harness = await startHarness({
+      configOverrides: {
+        groupChat: {
+          enabled: true,
+          requireMention: true,
+          mentionPatterns: ["@bot"],
+        },
+      },
+      replyPayloadFactory: () => ({ text: "不应发送" }),
+    });
+
+    try {
+      harness.wsClient.emit(
+        "message",
+        createMessageFrame({
+          chattype: "group",
+          chatid: "wr-group-empty-mention",
+          from: { userid: "guoyonghang" },
+          msgtype: "text",
+          text: { content: "@bot" },
+        }),
+      );
+
+      await delay(100);
+      assert.equal(harness.runtime.ctxs.length, 0);
+      assert.equal(harness.wsClient.replyStreamCalls.length, 0);
+    } finally {
+      await harness.stop();
+    }
+  });
+
   it("covers inbound image messages end-to-end", async () => {
     const imageUrl = "https://example.com/input.png";
     const harness = await startHarness({
@@ -816,6 +848,40 @@ describe("WS e2e", () => {
       const finals = harness.wsClient.replyStreamCalls.filter((c) => c.finish);
       assert.ok(finals.length >= 1);
       assert.ok(finals[0].content.includes("文件发送失败：没有权限访问路径"));
+    } finally {
+      await harness.stop();
+    }
+  });
+
+  it("allows passive reply files from configured mediaLocalRoots", async () => {
+    const customMediaDir = path.join(tempDir, "reply-local-root");
+    const customPdfPath = path.join(customMediaDir, "report.pdf");
+    await mkdir(customMediaDir, { recursive: true });
+    await writeFile(customPdfPath, Buffer.from("reply-pdf"));
+
+    const harness = await startHarness({
+      configOverrides: {
+        mediaLocalRoots: [customMediaDir],
+      },
+      replyPayloadFactory: () => ({
+        text: `附件如下\nFILE:${customPdfPath}`,
+      }),
+    });
+
+    try {
+      harness.wsClient.emit(
+        "message",
+        createMessageFrame({
+          msgtype: "text",
+          text: { content: "把配置目录里的 PDF 发我" },
+        }),
+      );
+
+      await eventually(() => assert.equal(harness.wsClient.uploadMediaCalls.length, 1));
+      await eventually(() => assert.equal(harness.wsClient.sendMediaMessageCalls.length, 1));
+      const finals = harness.wsClient.replyStreamCalls.filter((c) => c.finish);
+      assert.ok(finals.length >= 1);
+      assert.ok(finals[0].content.includes("附件如下"));
     } finally {
       await harness.stop();
     }

--- a/wecom/ws-monitor.js
+++ b/wecom/ws-monitor.js
@@ -357,10 +357,18 @@ function resolveAgentWorkspaceDir(config, agentId) {
   return path.join(stateDir, `workspace-${normalizedAgentId}`);
 }
 
+function resolveConfiguredReplyMediaLocalRoots(config) {
+  const roots = Array.isArray(config?.channels?.[CHANNEL_ID]?.mediaLocalRoots)
+    ? config.channels[CHANNEL_ID].mediaLocalRoots
+    : [];
+  return roots.map((entry) => resolveUserPath(entry)).filter(Boolean);
+}
+
 function resolveReplyMediaLocalRoots(config, agentId) {
   const workspaceDir = resolveAgentWorkspaceDir(config, agentId || resolveDefaultAgentId(config));
   const browserMediaDir = path.join(resolveStateDir(), "media", "browser");
-  return [...new Set([workspaceDir, browserMediaDir].map((entry) => path.resolve(entry)))];
+  const configuredRoots = resolveConfiguredReplyMediaLocalRoots(config);
+  return [...new Set([workspaceDir, browserMediaDir, ...configuredRoots].map((entry) => path.resolve(entry)))];
 }
 
 function mergeReplyMediaUrls(...lists) {
@@ -387,12 +395,12 @@ function mergeReplyMediaUrls(...lists) {
 function buildReplyMediaGuidance(config, agentId) {
   const workspaceDir = resolveAgentWorkspaceDir(config, agentId || resolveDefaultAgentId(config));
   const browserMediaDir = path.join(resolveStateDir(), "media", "browser");
-  return [
+  const configuredRoots = resolveConfiguredReplyMediaLocalRoots(config);
+  const guidance = [
     WECOM_REPLY_MEDIA_GUIDANCE_HEADER,
     `Local reply files are allowed only under the current workspace: ${workspaceDir}`,
     "Inside the agent sandbox, that same workspace is visible as /workspace.",
     `Browser-generated files are also allowed only under: ${browserMediaDir}`,
-    "Never reference any other host path.",
     "Do NOT call message.send or message.sendAttachment to deliver files back to the current WeCom chat/user; use MEDIA: or FILE: directives instead.",
     "For images: put each image path on its own line as MEDIA:/abs/path.",
     "If a local file is in the current sandbox workspace, use its /workspace/... path directly.",
@@ -402,7 +410,14 @@ function buildReplyMediaGuidance(config, agentId) {
     "CRITICAL: If a tool already returned a path prefixed with FILE: (e.g. FILE:/abs/path.pdf), keep the FILE: prefix exactly as-is. Do NOT change it to MEDIA:.",
     "Each directive MUST be on its own line with no other text on that line.",
     "The plugin will automatically send the media to the user.",
-  ].join("\n");
+  ];
+
+  if (configuredRoots.length > 0) {
+    guidance.push(`Additional configured host roots are also allowed: ${configuredRoots.join(", ")}`);
+  }
+
+  guidance.push("Never reference any other host path.");
+  return guidance.join("\n");
 }
 
 function normalizeReplyMediaUrlForLoad(mediaUrl, config, agentId) {
@@ -1072,6 +1087,14 @@ async function processWsMessage({ frame, account, config, runtime, wsClient, req
       return;
     }
     text = extractGroupMessageContent(originalText, account.config);
+    if (!text.trim() && imageUrls.length === 0 && fileUrls.length === 0) {
+      logger.debug("[WS] Group message mention stripped to empty content; skipping reply", {
+        accountId: account.accountId,
+        chatId,
+        senderId,
+      });
+      return;
+    }
   }
 
   const senderIsAdmin = isWecomAdmin(senderId, account.config);


### PR DESCRIPTION
## Summary
- honor `channels.wecom.mediaLocalRoots` for passive reply media delivery in the WS reply path
- surface configured host media roots in reply-media guidance so the model can use allowed paths
- skip group messages that become empty after mention stripping, preventing placeholder replies like `处理完成。`
- add regression coverage for configured passive reply roots and mention-only group messages

## Testing
- node --test tests/reply-media-directive.test.js
- node --test tests/ws.e2e.test.js