### PR TITLE
fix: prevent phone numbers from being misidentified as department IDs

### DIFF
--- a/tests/target.test.js
+++ b/tests/target.test.js
@@ -41,4 +41,20 @@ describe("resolveWecomTarget", () => {
     // "webhook:wecom:something" should NOT strip "wecom:" — it's a webhook name
     assert.deepEqual(resolveWecomTarget("webhook:wecom:something"), { webhook: "wecom:something" });
   });
+
+  it("treats short digit strings as department (party) IDs", () => {
+    assert.deepEqual(resolveWecomTarget("2"), { toParty: "2" });
+    assert.deepEqual(resolveWecomTarget("999"), { toParty: "999" });
+    assert.deepEqual(resolveWecomTarget("wecom:42"), { toParty: "42" });
+    assert.deepEqual(resolveWecomTarget("123456"), { toParty: "123456" });
+  });
+
+  it("treats long digit strings (phone numbers) as user IDs", () => {
+    assert.deepEqual(resolveWecomTarget("wecom:13800001111"), { toUser: "13800001111" });
+    assert.deepEqual(resolveWecomTarget("1380000111"), { toUser: "1380000111" });
+  });
+
+  it("explicit party: prefix still works for long digit strings", () => {
+    assert.deepEqual(resolveWecomTarget("party:13800001111"), { toParty: "13800001111" });
+  });
 });

--- a/wecom/target.js
+++ b/wecom/target.js
@@ -47,8 +47,9 @@ export function resolveWecomTarget(raw) {
   if (/^(wr|wc)/i.test(clean)) {
     return { chatId: clean };
   }
-  // Pure digits are likely department (party) IDs.
-  if (/^\d+$/.test(clean)) {
+  // Short pure-digit strings (≤6 digits) are department (party) IDs.
+  // Longer digit strings (phone numbers, external IDs) fall through to toUser.
+  if (/^\d{1,6}$/.test(clean)) {
     return { toParty: clean };
   }
 


### PR DESCRIPTION
## Summary
- **Bug**: The heuristic regex `/^\d+$/` in `wecom/target.js` treated any pure-digit string as a department (party) ID, causing 11-digit phone numbers to be sent as `toParty` instead of `toUser` — WeCom API returns error 81013 ("user & party & tag all invalid")
- **Fix**: Narrowed regex to `/^\d{1,6}$/` so only 1–6 digit strings are treated as department IDs; 7+ digit strings (phone numbers, external IDs) fall through to `toUser`
- Added test cases covering short digit → party, long digit → user, and explicit `party:` prefix override

## Test plan
- [x] Short digit strings (`2`, `999`, `123456`) → `{ toParty }` ✅
- [x] Long digit strings (`13800001111`) → `{ toUser }` ✅
- [x] Namespaced long digits (`wecom:13800001111`) → `{ toUser }` ✅
- [x] Explicit prefix (`party:13800001111`) → `{ toParty }` (unaffected) ✅
- [x] All 12 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)