### PR TITLE
fix: skip WS monitor for callback-only accounts in startAccount

### DIFF
--- a/wecom/channel-plugin.js
+++ b/wecom/channel-plugin.js
@@ -618,6 +618,17 @@ export const wecomChannelPlugin = {
       setConfigProxyUrl(network.egressProxyUrl ?? "");
       setApiBaseUrl(network.apiBaseUrl ?? "");
 
+      // Callback-only accounts (Agent API) don't need WS monitor.
+      // Return a promise that stays alive until the gateway signals shutdown,
+      // so the account is marked as running (not exited → no auto-restart).
+      if (!ctx.account.botId && !ctx.account.secret) {
+        return new Promise((resolve) => {
+          if (ctx.abortSignal) {
+            ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+          }
+        });
+      }
+
       return startWsMonitor({
         account: ctx.account,
         config: ctx.cfg,


### PR DESCRIPTION
## Summary

- Callback-only accounts (Agent API mode, e.g. configured with `corpId`/`corpSecret`/`agentId` but no `botId`/`secret`) crash on `gateway restart` because `startAccount()` unconditionally calls `startWsMonitor()`, which requires WS credentials.
- The missing credentials cause immediate exit → auto-restart loop → account permanently stopped after 10 retries.
- Added a guard before `startWsMonitor()`: if neither `botId` nor `secret` is present, return a long-lived promise (resolved on `abortSignal`) so the account stays in "running" state without a WS connection.

## Test plan

- [x] Verified on OpenClaw v2026.3.7 with `@sunnoy/wecom` v2.3.0
- [x] `gateway restart` no longer triggers restart loops for callback-only accounts (tim/devin)
- [x] WS-based accounts (default/yoyo/david) unaffected — still connect normally
- [x] Agent API inbound (callback) and outbound (Agent API) messaging works as before