### PR TITLE
fix: limit admin bypass to DM routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ npm test
 | 配置项 | 类型 | 必填 | 说明 |
 | --- | --- | --- | --- |
 | `channels.wecom.dynamicAgents.enabled` | boolean | 否 | 是否启用动态 Agent，默认 `true` |
-| `channels.wecom.dynamicAgents.adminBypass` | boolean | 否 | 管理员是否绕过动态 Agent，默认 `false` |
+| `channels.wecom.dynamicAgents.adminBypass` | boolean | 否 | 管理员私聊是否绕过动态 Agent，默认 `false`；群聊不受此项影响，仍按群路由 |
 | `channels.wecom.dm.createAgentOnFirstMessage` | boolean | 否 | 私聊是否按用户建独立 Agent，默认 `true` |
 | `channels.wecom.groupChat.enabled` | boolean | 否 | 是否启用群聊处理，默认 `true` |
 | `channels.wecom.groupChat.requireMention` | boolean | 否 | 群聊是否要求 @ 才响应，默认 `true` |

--- a/dynamic-agent.js
+++ b/dynamic-agent.js
@@ -59,7 +59,7 @@ export function shouldUseDynamicAgent({ chatType, config, senderIsAdmin = false 
   if (!dynamicConfig.enabled) {
     return false;
   }
-  if (senderIsAdmin && dynamicConfig.adminBypass) {
+  if (chatType === "dm" && senderIsAdmin && dynamicConfig.adminBypass) {
     return false;
   }
   if (chatType === "group") {

--- a/tests/dynamic-agent.test.js
+++ b/tests/dynamic-agent.test.js
@@ -41,6 +41,19 @@ describe("shouldUseDynamicAgent", () => {
     });
     assert.equal(useDynamic, true);
   });
+
+  it("keeps group routing on the group agent for admin when adminBypass is enabled", () => {
+    const config = {
+      dynamicAgents: { enabled: true, adminBypass: true },
+      groupChat: { enabled: true },
+    };
+    const useDynamic = shouldUseDynamicAgent({
+      chatType: "group",
+      config,
+      senderIsAdmin: true,
+    });
+    assert.equal(useDynamic, true);
+  });
 });
 
 describe("extractGroupMessageContent", () => {


### PR DESCRIPTION
## Summary
- keep group messages on the group dynamic agent even when the sender is an admin and adminBypass is enabled
- keep adminBypass behavior for DM routing unchanged
- document that adminBypass only applies to DM routing

## Tests
- node --test tests/dynamic-agent.test.js
- npm test (fails: existing macOS /var vs /private/var path/sandbox assertions in callback/media tests; 292/294 passed)